### PR TITLE
Feat/create equipament

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ServicesModule } from './common/services/services.module';
+import { EquipamentModule } from './modules/equipament/equipament.module';
 
 @Module({
-  imports: [ServicesModule],
+  imports: [ServicesModule, EquipamentModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/common/services/prisma/prisma.service.spec.ts
+++ b/src/common/services/prisma/prisma.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PrismaService } from './prisma.service';
+
+describe('PrismaService', () => {
+  let service: PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaService],
+    }).compile();
+
+    service = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/common/services/prisma/prisma.service.ts
+++ b/src/common/services/prisma/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+  }
+}

--- a/src/common/services/services.module.ts
+++ b/src/common/services/services.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 
 import { LoggerService } from './logger/logger.service';
+import { PrismaService } from './prisma/prisma.service';
 
 @Module({
-  providers: [LoggerService],
+  providers: [LoggerService, PrismaService],
+  exports: [PrismaService],
 })
 export class ServicesModule {}

--- a/src/common/types/api-response.type.ts
+++ b/src/common/types/api-response.type.ts
@@ -1,0 +1,8 @@
+export type ApiResponse<T> = {
+  data: T;
+  pagination?: {
+    skip: number;
+    limit: number;
+  };
+  total?: number;
+};

--- a/src/common/types/api-response.type.ts
+++ b/src/common/types/api-response.type.ts
@@ -1,4 +1,4 @@
-export type ApiResponse<T> = {
+export type ApiResponseType<T> = {
   data: T;
   pagination?: {
     skip: number;

--- a/src/dtos/equipament.dto.ts
+++ b/src/dtos/equipament.dto.ts
@@ -1,21 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, MaxLength, Length } from 'class-validator';
 
 export class EquipamentDto {
+  @ApiProperty({
+    description: 'Nome do equipamento',
+    example: 'Lenovo ThinkPad E14',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   name: string;
 
+  @ApiProperty({
+    description: 'Prefixo do equipamento',
+    example: 'NB',
+  })
   @IsString()
   @IsNotEmpty()
   @Length(1, 3)
   prefix: string;
 
+  @ApiProperty({
+    description: 'Categoria do equipamento',
+    example: 'Notebook',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)
   category: string;
 
+  @ApiProperty({
+    description: 'Marca do equipamento',
+    example: 'Lenovo',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)

--- a/src/dtos/equipament.dto.ts
+++ b/src/dtos/equipament.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsNotEmpty, MaxLength, Length } from 'class-validator';
+
+export class EquipamentDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 3)
+  prefix: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  category: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  brand: string;
+}

--- a/src/modules/equipament/equipament.controller.spec.ts
+++ b/src/modules/equipament/equipament.controller.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { EquipamentController } from './equipament.controller';
+
+describe('EquipamentController', () => {
+  let controller: EquipamentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EquipamentController],
+    }).compile();
+
+    controller = module.get<EquipamentController>(EquipamentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/equipament/equipament.controller.spec.ts
+++ b/src/modules/equipament/equipament.controller.spec.ts
@@ -1,19 +1,55 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { EquipamentController } from './equipament.controller';
+import { EquipamentService } from './equipament.service';
 
 describe('EquipamentController', () => {
   let controller: EquipamentController;
+  let service: EquipamentService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EquipamentController],
+      providers: [
+        {
+          provide: EquipamentService,
+          useValue: {
+            create: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<EquipamentController>(EquipamentController);
+    service = module.get<EquipamentService>(EquipamentService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should create a new equipment successfully', async () => {
+    const equipamentDto = {
+      name: 'Equipament 1',
+      brand: 'Dell',
+      category: 'Notebook',
+      prefix: 'NB',
+    };
+
+    const createdEquipament = {
+      id: 1,
+      ...equipamentDto,
+      active: true,
+      createdAt: new Date(),
+      updatedAt: null,
+      deletedAt: null,
+    };
+
+    service.create = jest.fn().mockResolvedValue(createdEquipament);
+
+    const result = await controller.create(equipamentDto);
+
+    expect(service.create).toHaveBeenCalledWith(equipamentDto);
+    expect(result).toEqual({ data: createdEquipament });
   });
 });

--- a/src/modules/equipament/equipament.controller.ts
+++ b/src/modules/equipament/equipament.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { Equipament } from '@prisma/client';
+
+import { EquipamentService } from './equipament.service';
+
+import { EquipamentDto } from '@ds-dtos/equipament.dto';
+import { ApiResponse } from '@ds-common/types/api-response.type';
+
+@Controller('equipament')
+export class EquipamentController {
+  constructor(private readonly equipamentService: EquipamentService) {}
+
+  @Post()
+  public async create(
+    @Body() equipamentDto: EquipamentDto,
+  ): Promise<ApiResponse<Equipament>> {
+    const equipament = await this.equipamentService.create(equipamentDto);
+
+    return { data: equipament };
+  }
+}

--- a/src/modules/equipament/equipament.controller.ts
+++ b/src/modules/equipament/equipament.controller.ts
@@ -4,16 +4,59 @@ import { Equipament } from '@prisma/client';
 import { EquipamentService } from './equipament.service';
 
 import { EquipamentDto } from '@ds-dtos/equipament.dto';
-import { ApiResponse } from '@ds-common/types/api-response.type';
+import { ApiResponseType } from '@ds-common/types/api-response.type';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('equipament')
 export class EquipamentController {
   constructor(private readonly equipamentService: EquipamentService) {}
 
+  @ApiOperation({
+    summary: 'Cadastra um novo equipamento',
+    description: 'Este endpoint permite criar um novo equipamento no sistema.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Equipamento criado com sucesso',
+    schema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            id: { type: 'number' },
+            name: { type: 'string' },
+            prefix: { type: 'string' },
+            category: { type: 'string' },
+            brand: { type: 'string' },
+            active: { type: 'boolean' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time', nullable: true },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Equipamento com o mesmo nome já existe',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        error: { type: 'string' },
+        statusCode: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Equipamento com o mesmo nome já existe',
+  })
   @Post()
   public async create(
     @Body() equipamentDto: EquipamentDto,
-  ): Promise<ApiResponse<Equipament>> {
+  ): Promise<ApiResponseType<Equipament>> {
     const equipament = await this.equipamentService.create(equipamentDto);
 
     return { data: equipament };

--- a/src/modules/equipament/equipament.controller.ts
+++ b/src/modules/equipament/equipament.controller.ts
@@ -1,11 +1,11 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { Equipament } from '@prisma/client';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 import { EquipamentService } from './equipament.service';
 
 import { EquipamentDto } from '@ds-dtos/equipament.dto';
 import { ApiResponseType } from '@ds-common/types/api-response.type';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('equipament')
 export class EquipamentController {
@@ -32,6 +32,7 @@ export class EquipamentController {
             active: { type: 'boolean' },
             createdAt: { type: 'string', format: 'date-time' },
             updatedAt: { type: 'string', format: 'date-time', nullable: true },
+            deletedAt: { type: 'string', format: 'date-time', nullable: true },
           },
         },
       },

--- a/src/modules/equipament/equipament.module.ts
+++ b/src/modules/equipament/equipament.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { EquipamentService } from './equipament.service';
+import { EquipamentController } from './equipament.controller';
+import { EquipamentRepository } from './equipament.repository';
+
+import { ServicesModule } from '@ds-common/services/services.module';
+
+@Module({
+  imports: [ServicesModule],
+  providers: [EquipamentService, EquipamentRepository],
+  controllers: [EquipamentController],
+})
+export class EquipamentModule {}

--- a/src/modules/equipament/equipament.repository.spec.ts
+++ b/src/modules/equipament/equipament.repository.spec.ts
@@ -1,0 +1,64 @@
+import { EquipamentRepository } from './equipament.repository';
+
+import { PrismaService } from '@ds-common/services/prisma/prisma.service';
+import { EquipamentDto } from '@ds-dtos/equipament.dto';
+
+describe('EquipamentRepository', () => {
+  let repository: EquipamentRepository;
+  let prismaService: PrismaService;
+
+  beforeEach(() => {
+    prismaService = new PrismaService();
+    repository = new EquipamentRepository(prismaService);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  it('should create a new equipament', async () => {
+    const equipamentDto: EquipamentDto = {
+      name: 'Equipament 1',
+      brand: 'Dell',
+      category: 'Notebook',
+      prefix: 'NB',
+    };
+    const createdEquipament = {
+      id: 1,
+      ...equipamentDto,
+      active: true,
+      createdAt: new Date(),
+      updatedAt: null,
+      deletedAt: null,
+    };
+
+    prismaService.equipament.create = jest
+      .fn()
+      .mockResolvedValue(createdEquipament);
+
+    const result = await repository.create(equipamentDto);
+    expect(result).toEqual(createdEquipament);
+  });
+
+  it('should find an equipament by name', async () => {
+    const equipamentName = 'Equipamento 1';
+    const equipament = {
+      id: 1,
+      name: equipamentName,
+      prefix: 'EQ1',
+      active: true,
+      createdAt: new Date(),
+      brand: 'BrandA',
+      category: 'Category A',
+      updatedAt: null,
+      deletedAt: null,
+    };
+
+    prismaService.equipament.findUnique = jest
+      .fn()
+      .mockResolvedValue(equipament);
+
+    const result = await repository.findByName(equipamentName);
+    expect(result).toEqual(equipament);
+  });
+});

--- a/src/modules/equipament/equipament.repository.ts
+++ b/src/modules/equipament/equipament.repository.ts
@@ -1,0 +1,26 @@
+import { Equipament } from '@prisma/client';
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '@ds-common/services/prisma/prisma.service';
+import { EquipamentDto } from '@ds-dtos/equipament.dto';
+
+@Injectable()
+export class EquipamentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  public async create(equipament: EquipamentDto): Promise<Equipament> {
+    return await this.prisma.equipament.create({ data: equipament });
+  }
+
+  public async findByName<T extends Prisma.EquipamentSelect>(
+    name: string,
+    select?: T,
+    active = true,
+  ): Promise<Prisma.EquipamentGetPayload<{ select: T }> | null> {
+    return this.prisma.equipament.findUnique({
+      where: { name, active },
+      select,
+    });
+  }
+}

--- a/src/modules/equipament/equipament.service.spec.ts
+++ b/src/modules/equipament/equipament.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { EquipamentService } from './equipament.service';
+
+describe('EquipamentService', () => {
+  let service: EquipamentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EquipamentService],
+    }).compile();
+
+    service = module.get<EquipamentService>(EquipamentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/equipament/equipament.service.spec.ts
+++ b/src/modules/equipament/equipament.service.spec.ts
@@ -1,19 +1,82 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
 
 import { EquipamentService } from './equipament.service';
+import { EquipamentRepository } from './equipament.repository';
+
+import { EquipamentDto } from '@ds-dtos/equipament.dto';
 
 describe('EquipamentService', () => {
   let service: EquipamentService;
+  let repository: EquipamentRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [EquipamentService],
+      providers: [
+        EquipamentService,
+        {
+          provide: EquipamentRepository,
+          useValue: {
+            create: jest.fn(),
+            findByName: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<EquipamentService>(EquipamentService);
+    repository = module.get<EquipamentRepository>(EquipamentRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should create a new equipment succesffuly', async () => {
+    const equipamentDto: EquipamentDto = {
+      name: 'Equipament 1',
+      brand: 'Dell',
+      category: 'Notebook',
+      prefix: 'NB',
+    };
+
+    repository.findByName = jest.fn().mockResolvedValue(null);
+    repository.create = jest.fn().mockResolvedValue({
+      id: 1,
+      ...equipamentDto,
+      active: true,
+      createdAt: new Date(),
+      updatedAt: null,
+      deletedAt: null,
+    });
+
+    const result = await service.create(equipamentDto);
+
+    expect(repository.findByName).toHaveBeenCalledWith(equipamentDto.name, {
+      id: true,
+    });
+    expect(repository.create).toHaveBeenCalledWith(equipamentDto);
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('name', equipamentDto.name);
+  });
+
+  it('should throw a conflict exception when trying to create an existing equipment', async () => {
+    const equipamentDto: EquipamentDto = {
+      name: 'Equipament 1',
+      brand: 'Dell',
+      category: 'Notebook',
+      prefix: 'NB',
+    };
+
+    repository.findByName = jest.fn().mockResolvedValue({
+      id: 1,
+    });
+
+    await expect(service.create(equipamentDto)).rejects.toThrow(
+      new ConflictException(
+        `Equipment with the name "${equipamentDto.name}" already exists`,
+      ),
+    );
+    expect(repository.create).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/modules/equipament/equipament.service.ts
+++ b/src/modules/equipament/equipament.service.ts
@@ -1,0 +1,26 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { Equipament } from '@prisma/client';
+
+import { EquipamentRepository } from './equipament.repository';
+
+import { EquipamentDto } from '@ds-dtos/equipament.dto';
+
+@Injectable()
+export class EquipamentService {
+  constructor(private readonly equipamentRepository: EquipamentRepository) {}
+
+  public async create(equipament: EquipamentDto): Promise<Equipament> {
+    const equipamentExists = await this.equipamentRepository.findByName(
+      equipament.name,
+      { id: true },
+    );
+
+    if (equipamentExists) {
+      throw new ConflictException(
+        `Equipment with the name "${equipament.name}" already exists`,
+      );
+    }
+
+    return await this.equipamentRepository.create(equipament);
+  }
+}


### PR DESCRIPTION
### O que foi feito
Desenvolvimento da funcionalidade cadastro de equipamentos, possibilitando registrar os equipamentos que podem ser disponibilizados pela empresa. Para isso foi desenvolvido:
- Endpoint `POST api/v1/equipament`
- Valida se já existe um equipamento com o nome informado
- Testes unitários em caso de sucesso e falha
- Documentação no swagger